### PR TITLE
https://github.com/cwebd/k3os-vagrant/issues/2

### DIFF
--- a/packer/vagrant.json
+++ b/packer/vagrant.json
@@ -9,10 +9,10 @@
             "type": "qemu",
             "accelerator": "kvm",
             "display": "none",
-            "boot_wait": "6s",
+            "boot_wait": "30s",
             "boot_command": [
                 "<enter>",
-                "<wait20>",
+                "<wait40>",
                 "rancher",
                 "<enter>",
                 "sudo k3os install",
@@ -44,10 +44,10 @@
         },
         {
             "type": "virtualbox-iso",
-            "boot_wait": "6s",
+            "boot_wait": "30s",
             "boot_command": [
                 "<enter>",
-                "<wait20>",
+                "<wait40>",
                 "rancher",
                 "<enter>",
                 "sudo k3os install",


### PR DESCRIPTION
 - Increase the boot wait from 6s and increase the boot command wait from 20 seconds to 40 seconds to allow for the system to settle before the box setup