### PR TITLE
Multi server vagrant nugrant configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-k3os_virtualbox.box
+.vagrant
+.vagrantuser
+config.yaml
 packer/packer_cache
 packer/build
-.vagrant

--- a/.vagrantuser.example
+++ b/.vagrantuser.example
@@ -1,0 +1,212 @@
+# Define k3os cluster configuration
+
+bridge_interface: em1
+provider: libvrt
+#provision_debug: true
+
+# Single Server
+servers:
+  'server1':
+    macaddress2: '7e522693e957'
+    k3os_config: 'config.yaml'
+    k3os_config_env:
+      hostname:  "k3s-server-01.cluster.k3s"
+      k3os_password: "rancher"
+      k3os_token: "a6715b0fa4dca52833f2791e8ab1476f25ca0e137cd52ca13d40f33c4896a174"
+      k3os_server_url: ""
+      k3os_args_node_ip: 192.168.1.115
+      k3os_args_external_ip: 192.168.1.115
+      k3os_args_flannel_iface: eth1
+      k3os_args_k3s_args:
+        - server
+        - "--cluster-init"
+        - "--node-ip=$k3os_args_node_ip"
+        - "--node-external-ip=$k3os_args_node_ip"
+        - "--flannel-iface=$k3os_args_flannel_iface"
+        - "--flannel-backend=wireguard"
+        - "--disable-agent=false"
+    cpus:  4
+    memory:  1024
+
+# Three Servers
+
+# servers:
+#   'server1':
+#     macaddress2: '7e522693e957'
+#     k3os_config: 'config.yaml'
+#     k3os_config_env:
+#       hostname:  "k3s-server-01.cluster.k3s"
+#       k3os_password: "rancher"
+#       k3os_token: "a6715b0fa4dca52833f2791e8ab1476f25ca0e137cd52ca13d40f33c4896a174"
+#       k3os_server_url: ""
+#       k3os_args_node_ip: 192.168.1.115
+#       k3os_args_external_ip: 192.168.1.115
+#       k3os_args_flannel_iface: eth1
+#       k3os_args_k3s_args:
+#         - server
+#         - "--cluster-init"
+#         - "--node-ip=$k3os_args_node_ip"
+#         - "--node-external-ip=$k3os_args_node_ip"
+#         - "--flannel-iface=$k3os_args_flannel_iface"
+#         - "--flannel-backend=wireguard"
+#         - "--disable-agent=false"
+#     cpus:  4
+#     memory:  1024
+#   'server2':
+#     macaddress2: '224863aa8bde'
+#     k3os_config: 'config.yaml'
+#     k3os_config_env:
+#       hostname:  "k3s-server-02.cluster.k3s"
+#       k3os_password: "rancher"
+#       k3os_token: "a6715b0fa4dca52833f2791e8ab1476f25ca0e137cd52ca13d40f33c4896a174"
+#       k3os_server_url: "https://192.168.1.115:6443"
+#       k3os_args_node_ip: 192.168.1.116
+#       k3os_args_external_ip: 192.168.1.116
+#       k3os_args_flannel_iface: eth1
+#       k3os_args_k3s_args:
+#         - server
+#         - "--node-ip=$k3os_args_node_ip"
+#         - "--node-external-ip=$k3os_args_node_ip"
+#         - "--flannel-iface=$k3os_args_flannel_iface"
+#         - "--flannel-backend=wireguard"
+#         - "--disable-agent=false"
+#     cpus:  4
+#     memory:  1024
+#   'server3':
+#     macaddress2: '6eb0b992eb1b'
+#     k3os_config: 'config.yaml'
+#     k3os_config_env:
+#       hostname:  "k3s-server-03.cluster.k3s"
+#       k3os_password: "rancher"
+#       k3os_token: "a6715b0fa4dca52833f2791e8ab1476f25ca0e137cd52ca13d40f33c4896a174"
+#       k3os_server_url: "https://192.168.1.115:6443"
+#       k3os_args_node_ip: 192.168.1.117
+#       k3os_args_external_ip: 192.168.1.117
+#       k3os_args_flannel_iface: eth1
+#       k3os_args_k3s_args:
+#         - server
+#         - "--node-ip=$k3os_args_node_ip"
+#         - "--node-external-ip=$k3os_args_node_ip"
+#         - "--flannel-iface=$k3os_args_flannel_iface"
+#         - "--flannel-backend=wireguard"
+#         - "--disable-agent=false"
+#     cpus:  4
+#     memory:  1024
+
+# Three Servers, three agents
+# servers:
+#   'server1':
+#     macaddress2: '7e522693e957'
+#     k3os_config: 'config.yaml'
+#     k3os_config_env:
+#       hostname:  "k3s-server-01.cluster.k3s"
+#       k3os_password: "rancher"
+#       k3os_token: "a6715b0fa4dca52833f2791e8ab1476f25ca0e137cd52ca13d40f33c4896a174"
+#       k3os_server_url: ""
+#       k3os_args_node_ip: 192.168.1.115
+#       k3os_args_external_ip: 192.168.1.115
+#       k3os_args_flannel_iface: eth1
+#       k3os_args_k3s_args:
+#         - server
+#         - "--cluster-init"
+#         - "--node-ip=$k3os_args_node_ip"
+#         - "--node-external-ip=$k3os_args_node_ip"
+#         - "--flannel-iface=$k3os_args_flannel_iface"
+#         - "--flannel-backend=wireguard"
+#         - "--disable-agent=false"
+#     cpus:  4
+#     memory:  1024
+#   'server2':
+#     macaddress2: '224863aa8bde'
+#     k3os_config: 'config.yaml'
+#     k3os_config_env:
+#       hostname:  "k3s-server-02.cluster.k3s"
+#       k3os_password: "rancher"
+#       k3os_token: "a6715b0fa4dca52833f2791e8ab1476f25ca0e137cd52ca13d40f33c4896a174"
+#       k3os_server_url: "https://192.168.1.115:6443"
+#       k3os_args_node_ip: 192.168.1.116
+#       k3os_args_external_ip: 192.168.1.116
+#       k3os_args_flannel_iface: eth1
+#       k3os_args_k3s_args:
+#         - server
+#         - "--node-ip=$k3os_args_node_ip"
+#         - "--node-external-ip=$k3os_args_node_ip"
+#         - "--flannel-iface=$k3os_args_flannel_iface"
+#         - "--flannel-backend=wireguard"
+#         - "--disable-agent=false"
+#     cpus:  4
+#     memory:  1024
+#   'server3':
+#     macaddress2: '6eb0b992eb1b'
+#     k3os_config: 'config.yaml'
+#     k3os_config_env:
+#       hostname:  "k3s-server-03.cluster.k3s"
+#       k3os_password: "rancher"
+#       k3os_token: "a6715b0fa4dca52833f2791e8ab1476f25ca0e137cd52ca13d40f33c4896a174"
+#       k3os_server_url: "https://192.168.1.115:6443"
+#       k3os_args_node_ip: 192.168.1.117
+#       k3os_args_external_ip: 192.168.1.117
+#       k3os_args_flannel_iface: eth1
+#       k3os_args_k3s_args:
+#         - server
+#         - "--node-ip=$k3os_args_node_ip"
+#         - "--node-external-ip=$k3os_args_node_ip"
+#         - "--flannel-iface=$k3os_args_flannel_iface"
+#         - "--flannel-backend=wireguard"
+#         - "--disable-agent=false"
+#     cpus:  4
+#     memory:  1024
+#   'agent1':
+#     macaddress2: 'e248e1d0b174'
+#     k3os_config: 'config.yaml'
+#     k3os_config_env:
+#       hostname:  "k3s-agent-01.cluster.k3s"
+#       k3os_password: "rancher"
+#       k3os_token: "a6715b0fa4dca52833f2791e8ab1476f25ca0e137cd52ca13d40f33c4896a174"
+#       k3os_server_url: "https://192.168.1.115:6443"
+#       k3os_args_node_ip: 192.168.1.118
+#       k3os_args_external_ip: 192.168.1.118
+#       k3os_args_flannel_iface: eth1
+#       k3os_args_k3s_args:
+#         - agent
+#         - "--node-ip=$k3os_args_node_ip"
+#         - "--node-external-ip=$k3os_args_node_ip"
+#         - "--flannel-iface=$k3os_args_flannel_iface"
+#     cpus:  4
+#     memory:  1024
+#   'agent2':
+#     macaddress2: '4260f68f236e'
+#     k3os_config: 'config.yaml'
+#     k3os_config_env:
+#       hostname:  "k3s-agent-02.cluster.k3s"
+#       k3os_password: "rancher"
+#       k3os_token: "a6715b0fa4dca52833f2791e8ab1476f25ca0e137cd52ca13d40f33c4896a174"
+#       k3os_server_url: "https://192.168.1.115:6443"
+#       k3os_args_node_ip: 192.168.1.119
+#       k3os_args_external_ip: 192.168.1.119
+#       k3os_args_flannel_iface: eth1
+#       k3os_args_k3s_args:
+#         - agent
+#         - "--node-ip=$k3os_args_node_ip"
+#         - "--node-external-ip=$k3os_args_node_ip"
+#         - "--flannel-iface=$k3os_args_flannel_iface"
+#     cpus:  4
+#     memory:  1024
+#   'agent3':
+#     macaddress2: 'fed085a6919c'
+#     k3os_config: 'config.yaml'
+#     k3os_config_env:
+#       hostname:  "k3s-agent-03.cluster.k3s"
+#       k3os_password: "rancher"
+#       k3os_token: "a6715b0fa4dca52833f2791e8ab1476f25ca0e137cd52ca13d40f33c4896a174"
+#       k3os_server_url: "https://192.168.1.115:6443"
+#       k3os_args_node_ip: 192.168.1.120
+#       k3os_args_external_ip: 192.168.1.120
+#       k3os_args_flannel_iface: eth1
+#       k3os_args_k3s_args:
+#         - agent
+#         - "--node-ip=$k3os_args_node_ip"
+#         - "--node-external-ip=$k3os_args_node_ip"
+#         - "--flannel-iface=$k3os_args_flannel_iface"
+#     cpus:  4
+#     memory:  1024

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+- Add multi server configuration using .vagrantuser
+- K3os configuration provisioning
+
 1.0.1
  - Update README
  - k3os v0.10.1-rc1-1-g4e7da23-amd64

--- a/README.md
+++ b/README.md
@@ -1,20 +1,29 @@
 # k3OS on Vagrant
 
-Multi node cluster setup allowing for configuration via nugrant in vagrant.
+Vagrant setup allowing for single and multi server and agent configuration. Full configuration of the k3os configuration file with .vagrantuser server configuration. Provisioning handles the configuration updates with server restarting.
+
+The default configuration uses wireguard ensuring all node communication is encrypted.
 
 ## Quick Start
 
+`$>cp .vagrantuser.example .vagrantuser`
+
+Update the ip address to an address which can bridge your current network, to generate a mac address:
+
+`$>printf '%02x' $((0x$(od /dev/urandom -N1 -t x1 -An | cut -c 2-) & 0xFE | 0x02)); od /dev/urandom -N5 -t x1 -An | sed 's/ /:/g'`
+
+Update your networking DHCP lease to assign the ip address.
+
+`$>cp config.yaml.example config.yaml`
 `$>vagrant up`
 
 This will create a single k3os instance running k3s in master mode. To connect:
 
 `$>vagrant ssh`
 
-Retrieve the configuration from /etc/rancher/.... [TODO]
+Retrieve the configuration from /etc/rancher/k3s/k3s.yaml
 
-`$>ifconfig | grep eth0`
-
-Get the ip address of the instance.
+Update the server url to a server ip address as configured in config.yaml
 
 Update your local .kube/config with the contents of the k3s configuration file with the updated ip address.
 
@@ -22,11 +31,29 @@ On your local system:
 
 `$>kubectl get nodes`
 
-Should then deliver one k3os master server available.
+This should then deliver one k3os master server available.
 
-## Multi Instance setup
+## Multi server and agent setup with k3os configuration
 
-TODO
+By default there is a single config.yaml file which is used by all the servers/agents, this config.yaml file includes variables which are dynamically replaced on provisioning by values set in .vagrantuser k3os_config_env.
+
+New values can be created and used as variables within the config.yaml.
+
+A single config.yaml can be used for all the servers/agents or separated by defining the k3os_config value to the configuration path.
+
+When creating a multi server architecture use the server name to connect:
+
+`$>vagrant ssh server1`
+
+When using libvrt the virtual machine machine can be used to access and review the boxes.
+
+## Updating k3os configuration information
+
+When the .vagrantuser k3os configuration is updated, run:
+
+`$>vagrant provision`
+
+This will then deploy the new configuration, the provision scripts compare if the k3os config yaml matches the system k3os config yaml, if there are differences this file is copied across and the box is restarted so that the changes take effect.
 
 ## Building Packer boxes
 
@@ -36,9 +63,14 @@ TODO
 
 This will produce a libvrt and virtualbox .box to upload to vagrant cloud
 
+## Debugging the vagrant provision
+
+If provision_debug is set to true in the .vagrantuser then the provision scripts will not be removed from /home/rancher.
+
 ## Notes
 
-The Virtualbox guest additions are not installed
+ - The Virtualbox guest additions are not installed
+ - When deploying a multi server architecture there may be an additional master node which is not set as ready, this is because the instance name changes but still exists. Remove by running kubectl delete node $nodename
 
 ## References
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,146 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+
+Vagrant.configure("2") do |config|
+
+  config.user.defaults = {
+    'bridge_interface' => '',
+    'box' => 'cwebd/k3os',
+    'box_version' => '',
+    # Specify a box url to override the box from vagrant cloud
+    'box_url' => '',
+    'ssh_username' => 'rancher',
+    # Provider can be libvirt or virtualbox, set virtualbox as the default for compatibility
+    'provider' => 'virtualbox',
+    'driver' => 'kvm',
+    'keymap' => 'en-gb',
+    'provision_debug' => false,
+    'servers' => {
+      'server1' => {
+        'macaddress2' => '',
+        'k3os_config' => '',
+        'k3os_config_env' => {
+        },
+        'cpus' =>  1,
+        'memory' =>  1024,
+      }
+    }
+  }
+
+  if Vagrant.has_plugin? "vagrant-vbguest"
+    config.vbguest.no_install  = true
+    config.vbguest.auto_update = false
+    config.vbguest.no_remote   = true
+  end
+
+  # Override with the user configuration if present
+  # This sets the default provider, boxes can also override the provider
+  if config.user.provider != ""
+    provider = config.user.provider
+  end
+
+  config.ssh.username = config.user.ssh_username
+
+  config.vm.box = config.user.box
+  config.vm.box_check_update = true
+  config.vm.guest = :linux
+
+  bridge_interface = config.user.bridge_interface
+
+  # If a box_url is provided then the version cannot be passed across
+  if config.user.box_url != ''
+    config.vm.box_url = config.user.box_url
+  else
+    if config.user.box_version != ''
+      config.vm.box_version =  config.user.box_version
+    end
+  end
+
+  config.user.servers.each do |server, server_config|
+
+    config.vm.define server do |cfg|
+
+      if provider == 'libvrt'
+
+        cfg.vm.provider :libvirt do |vm, override|
+          vm.management_network_mode = "route"
+          vm.driver = config.user.driver
+          vm.cpus = server_config[:cpus]
+          vm.memory = server_config[:memory]
+          vm.keymap = config.user.keymap
+        end
+
+        if bridge_interface != ""
+            if server_config[:macaddress2] != ""
+              cfg.vm.network :public_network,
+                :dev => bridge_interface,
+                :mode => "bridge",
+                :type => "direct",
+                :mac => server_config[:macaddress2]
+            else
+              cfg.vm.network :public_network,
+                :dev => bridge_interface,
+                :mode => "bridge",
+                :type => "direct"
+            end
+        end
+      end
+
+      if provider == 'virtualbox'
+        # Virtualbox configuration
+        cfg.vm.provider :virtualbox do |vm, override|
+
+          if bridge_interface != ""
+            vm.customize ["modifyvm", :id, "--nic2", "bridged"]
+            vm.customize ["modifyvm", :id, "--bridgeadapter2", bridge_interface]
+          end
+
+          if server_config[:macaddress2] != ""
+            vm.customize ["modifyvm", :id, "--macaddress2", server_config[:macaddress2]]
+          end
+
+          vm.customize ["modifyvm", :id, "--natdnshostresolver1", "off"]
+          vm.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
+          vm.customize ["modifyvm", :id, "--acpi", "off"]
+          vm.customize ["modifyvm", :id, "--cpus", server_config[:cpus]]
+          vm.customize ["modifyvm", :id, "--memory", server_config[:memory]]
+
+        end
+      end
+
+      if server_config.k3os_config != ""
+
+        cfg.vm.provision "k3os-config-template", type: "file", source: server_config.k3os_config, destination: "/home/rancher/provision-k3os-config-template.yaml"
+
+        # If the k3os_config is not empty then write out the environment variables
+        k3os_config_env = "#!/bin/bash\n"
+        if server_config.has_key?(:k3os_config_env)
+          server_config.k3os_config_env.each do |arg, value|
+            k3os_config_env = k3os_config_env + "export " + arg.to_s + '=' + '"' + value.to_s + '"' + "\n"
+          end
+        end
+        # Create the k3os-config.yaml file including any variables
+        k3os_config_env = k3os_config_env + "\n" + "envsubst < provision-k3os-config-template.yaml > provision-k3os-config.yaml.tmp && mv provision-k3os-config.yaml.tmp provision-k3os-config.yaml"
+
+        require "base64"
+        # Upload the environment configuration
+        cfg.vm.provision "k3os-config-env", type: "shell",  inline: "echo " + Base64.strict_encode64(k3os_config_env) + " | base64 -d > provision-k3os-config-env.sh; chmod 755 provision-k3os-config-env.sh; ./provision-k3os-config-env.sh", upload_path: "/home/rancher/provision-shell-k3os-config-env.sh"
+
+        # If K3os configuration has updated, copy K3os config, remove the provision scripts and reboot
+        # Otherwise remove the provision scripts
+
+        # Set debug to true to debug the provisioning process
+
+        provision_remove = "rm provision*.sh && rm provision*.yaml"
+        if config.user.provision_debug == true
+          provision_remove = "echo \"Debug Mode: Not deleting provision files\""
+        end
+
+
+        cfg.vm.provision "copy-k3os-config", type: "shell", inline: "if ! cmp -s /home/rancher/provision-k3os-config.yaml /var/lib/rancher/k3os/config.yaml; then sudo cp /home/rancher/provision-k3os-config.yaml /var/lib/rancher/k3os/config.yaml && " + provision_remove + " && echo \"k3os configuration updated, rebooting\" && reboot; else " + provision_remove + "; fi", upload_path: "/home/rancher/provision-copy-k3os-config.sh"
+
+      end
+    end
+  end
+end

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -1,0 +1,20 @@
+hostname: "$hostname"
+k3os:
+  data_sources:
+  modules:
+    - wireguard
+  sysctl:
+    kernel.printk: 4 4 1 7
+    kernel.kptr_restrict: 1
+  ntp_servers:
+    - 1.uk.pool.ntp.org
+    - 2.uk.pool.ntp.org
+    - 3.uk.pool.ntp.org
+  dns_nameservers:
+    - 1.1.1.1
+    - 8.8.8.8
+  # Rancher User PW
+  password: "$k3os_password"
+  token: $k3os_token
+  server_url: $k3os_server_url
+  k3s_args: $k3os_args_k3s_args

--- a/packer/vagrantfile.template
+++ b/packer/vagrantfile.template
@@ -36,6 +36,12 @@ Vagrant.configure("2") do |config|
   config.vm.guest = :linux
   config.ssh.username = "rancher"
 
+  if Vagrant.has_plugin? "vagrant-vbguest"
+    config.vbguest.no_install  = true
+    config.vbguest.auto_update = false
+    config.vbguest.no_remote   = true
+  end
+
   config.vm.provider :libvirt do |libvrt|
     libvrt.management_network_mode = "route"
     libvrt.driver = "kvm"


### PR DESCRIPTION
Closes #4 

- If vagrant-vbguest is present do not update the tools
 - Vagrantfile update to use envsubst to replace .vagrantuser configuration as environment variables to allow for dynamic k3os config.yaml
 - Add debug mode to review the provision files
 - Move provision_debug into the user configuration
 - Move the configuration to example files
 - Add README instructions for server configuration
 - Additional instructions for setup
 - Update changelog