### PR TITLE
k3os_config_env write_files, init_cmd, boot_cmd and run_cmd can't be set via .vagrantuser

### DIFF
--- a/.vagrantuser.example
+++ b/.vagrantuser.example
@@ -11,6 +11,7 @@ servers:
     k3os_config: 'config.yaml'
     k3os_config_env:
       hostname:  "k3s-server-01.cluster.k3s"
+      write_files:
       k3os_password: "rancher"
       k3os_token: "a6715b0fa4dca52833f2791e8ab1476f25ca0e137cd52ca13d40f33c4896a174"
       k3os_server_url: ""
@@ -25,6 +26,10 @@ servers:
         - "--flannel-iface=$k3os_args_flannel_iface"
         - "--flannel-backend=wireguard"
         - "--disable-agent=false"
+      init_cmd:
+      boot_cmd:
+      run_cmd:
+      - "/etc/init.d/crond start"
     cpus:  4
     memory:  1024
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,6 @@ If provision_debug is set to true in the .vagrantuser then the provision scripts
 ## Notes
 
  - The Virtualbox guest additions are not installed
- - When deploying a multi server architecture there may be an additional master node which is not set as ready, this is because the instance name changes but still exists. Remove by running kubectl delete node $nodename
 
 ## References
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -1,4 +1,8 @@
 hostname: "$hostname"
+write_files: $write_files
+init_cmd: $init_cmd
+boot_cmd: $boot_cmd
+run_cmd: $run_cmd
 k3os:
   data_sources:
   modules:


### PR DESCRIPTION
Add ability to use write_files, init_cmd, boot_cmd and run_cmd within .vagrantuser to pass through to k3os]

#12 